### PR TITLE
Update KO vs SUB multiplier and add README for backend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# FastAPI Backend
+
+This repository contains a FastAPI backend that can be run with Uvicorn.
+
+## Requirements
+
+- Python 3.10+
+- Install dependencies:  
+
+    ```bash
+    pip install -r requirements.txt
+    uvicorn app.main:app --reload
+    ```

--- a/backend/app/elo_engine/elo_calculator.py
+++ b/backend/app/elo_engine/elo_calculator.py
@@ -17,7 +17,7 @@ def calculate_elo(fighter_1_elo: Union[float, int], fighter_2_elo: Union[float, 
         S_fighter_1 = 0.5
         S_fighter_2 = 0.5
     else:
-        return fighter_1_elo, fighter_2_elo  # No change for no contest (nc)
+        return fighter_1_elo, fighter_2_elo
 
     fighter_1_elo_new = fighter_1_elo + k_factor * (S_fighter_1 - expected_score_fighter_1)
     fighter_2_elo_new = fighter_2_elo + k_factor * (S_fighter_2 - expected_score_fighter_2)
@@ -27,7 +27,14 @@ def expected_score(current_elo: Union[float, int], opponent_elo: Union[float, in
     return 1 / (1 + 10**((opponent_elo - current_elo)/denom))
 
 def get_k_factor(method: str, k: Union[float, str], multiplier: Union[float, int]):
-    if method == 'KO/TKO' or method == 'SUB':
-        return k * multiplier  # Increase K by 15% for KO or submission
+    if method == 'KO/TKO':
+        return k * multiplier
+    elif method == 'SUB':
+        multiplier_increase = multiplier - 1
+        # should not be < 0. If == 0, then multiplier results in no change
+        if multiplier_increase <= 0:
+            return k * multiplier
+        else:
+            return k * (1 + (multiplier_increase * 0.5))
     else:
         return k

--- a/backend/app/elo_engine/elo_calculator.py
+++ b/backend/app/elo_engine/elo_calculator.py
@@ -35,6 +35,6 @@ def get_k_factor(method: str, k: Union[float, str], multiplier: Union[float, int
         if multiplier_increase <= 0:
             return k * multiplier
         else:
-            return k * (1 + (multiplier_increase * 0.5))
+            return k * (1 + (multiplier_increase * 0.8))
     else:
         return k


### PR DESCRIPTION
# Multiplier for SUB
SUB is a definitive win, but often times not as dominant as a performance as a KO/TKO finish. Instead of multiplying by the same amount as for a KO/TKO win, they get 80% of the prescribed increase in score as they would for a KO/TKO. In this case, KO/TKO has a multiplier of 1.15, making the SUB multiplier 1.12 (0.8 * 0.15 = 0.12).

# README.md for backend
Created a concise README.md for running the backend locally.